### PR TITLE
Add the Key and Relay guid already exists specific exceptions

### DIFF
--- a/api/src/main/java/org/ccci/idm/user/DefaultUserManager.java
+++ b/api/src/main/java/org/ccci/idm/user/DefaultUserManager.java
@@ -84,10 +84,10 @@ public class DefaultUserManager implements UserManager {
 
         // throw an error if the raw Relay or The Key guid exists already
         if (user.getRawRelayGuid() != null && this.doesRelayGuidExist(user.getRawRelayGuid())) {
-            throw new UserException("Relay guid '" + user.getRawRelayGuid() + "' already exists");
+            throw new RelayGuidAlreadyExistsException("Relay guid '" + user.getRawRelayGuid() + "' already exists");
         }
         if (user.getRawTheKeyGuid() != null && this.doesTheKeyGuidExist(user.getRawTheKeyGuid())) {
-            throw new UserException("The Key guid '" + user.getRawTheKeyGuid() + "' already exists");
+            throw new TheKeyGuidAlreadyExistsException("The Key guid '" + user.getRawTheKeyGuid() + "' already exists");
         }
 
         // generate a guid for the user if there isn't a valid one already set

--- a/api/src/main/java/org/ccci/idm/user/RelayGuidAlreadyExistsException.java
+++ b/api/src/main/java/org/ccci/idm/user/RelayGuidAlreadyExistsException.java
@@ -1,0 +1,13 @@
+package org.ccci.idm.user;
+
+public class RelayGuidAlreadyExistsException extends UserException {
+    private static final long serialVersionUID = 6899292295712606400L;
+
+    public RelayGuidAlreadyExistsException() {
+        super();
+    }
+
+    public RelayGuidAlreadyExistsException(final String message) {
+        super(message);
+    }
+}

--- a/api/src/main/java/org/ccci/idm/user/TheKeyGuidAlreadyExistsException.java
+++ b/api/src/main/java/org/ccci/idm/user/TheKeyGuidAlreadyExistsException.java
@@ -1,0 +1,13 @@
+package org.ccci.idm.user;
+
+public class TheKeyGuidAlreadyExistsException extends UserException {
+    private static final long serialVersionUID = 5470942112218454006L;
+
+    public TheKeyGuidAlreadyExistsException() {
+        super();
+    }
+
+    public TheKeyGuidAlreadyExistsException(final String message) {
+        super(message);
+    }
+}


### PR DESCRIPTION
@frett I'd like to be able to distinguish between a general `UserException` and one where the guid already exists.
I also packaged the exceptions for neatness sake.
