### PR TITLE
reset forcePasswordChange flag after setting new password

### DIFF
--- a/api/src/main/java/org/ccci/idm/user/User.java
+++ b/api/src/main/java/org/ccci/idm/user/User.java
@@ -151,7 +151,12 @@ public class User implements Cloneable, Serializable {
     }
 
     public void setPassword(final String password) {
+        this.setPassword(password, false);
+    }
+
+    public void setPassword(final String password, final boolean forceChange) {
         this.password = password;
+        this.forcePasswordChange = forceChange;
     }
 
     public String getGuid() {

--- a/api/src/main/java/org/ccci/idm/user/dao/ldap/AbstractLdapUserDao.java
+++ b/api/src/main/java/org/ccci/idm/user/dao/ldap/AbstractLdapUserDao.java
@@ -33,8 +33,8 @@ import static org.ccci.idm.user.dao.ldap.Constants.LDAP_ATTR_TELEPHONE;
 import static org.ccci.idm.user.dao.ldap.Constants.LDAP_ATTR_USERID;
 import static org.ccci.idm.user.dao.ldap.Constants.LDAP_FLAG_ALLOWPASSWORDCHANGE;
 import static org.ccci.idm.user.dao.ldap.Constants.LDAP_FLAG_EMAILVERIFIED;
+import static org.ccci.idm.user.dao.ldap.Constants.LDAP_FLAG_FORCEPASSWORDCHANGE;
 import static org.ccci.idm.user.dao.ldap.Constants.LDAP_FLAG_LOGINDISABLED;
-import static org.ccci.idm.user.dao.ldap.Constants.LDAP_FLAG_STALEPASSWORD;
 
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
@@ -49,10 +49,10 @@ public abstract class AbstractLdapUserDao extends AbstractUserDao {
     private static final Map<Attr, Set<String>> MASK = ImmutableMap.<Attr, Set<String>>builder()
             .put(Attr.EMAIL, ImmutableSet.of(LDAP_ATTR_USERID, LDAP_FLAG_EMAILVERIFIED))
             .put(Attr.NAME, ImmutableSet.of(LDAP_ATTR_FIRSTNAME, LDAP_ATTR_LASTNAME))
-            .put(Attr.PASSWORD, ImmutableSet.of(LDAP_ATTR_PASSWORD))
+            .put(Attr.PASSWORD, ImmutableSet.of(LDAP_ATTR_PASSWORD, LDAP_FLAG_FORCEPASSWORDCHANGE))
             .put(Attr.LOGINTIME, ImmutableSet.of(LDAP_ATTR_LOGINTIME))
             .put(Attr.FLAGS, ImmutableSet.of(LDAP_FLAG_ALLOWPASSWORDCHANGE, LDAP_FLAG_EMAILVERIFIED,
-                    LDAP_FLAG_LOGINDISABLED, LDAP_FLAG_STALEPASSWORD))
+                    LDAP_FLAG_LOGINDISABLED, LDAP_FLAG_FORCEPASSWORDCHANGE))
             .put(Attr.DOMAINSVISITED, ImmutableSet.of(LDAP_ATTR_DOMAINSVISITED))
             .put(Attr.SELFSERVICEKEYS, ImmutableSet.of(LDAP_ATTR_CHANGEEMAILKEY, LDAP_ATTR_PROPOSEDEMAIL,
                     LDAP_ATTR_RESETPASSWORDKEY, LDAP_ATTR_SIGNUPKEY))

--- a/api/src/main/java/org/ccci/idm/user/dao/ldap/Constants.java
+++ b/api/src/main/java/org/ccci/idm/user/dao/ldap/Constants.java
@@ -26,9 +26,9 @@ public class Constants {
     public static final String LDAP_ATTR_PROPOSEDEMAIL = "thekeyProposedEmail";
 
     public static final String LDAP_FLAG_ALLOWPASSWORDCHANGE = "passwordAllowChange";
+    public static final String LDAP_FLAG_FORCEPASSWORDCHANGE = "thekeyPasswordForceChange";
     public static final String LDAP_FLAG_LOGINDISABLED = "loginDisabled";
     public static final String LDAP_FLAG_LOCKED = "lockedByIntruder";
-    public static final String LDAP_FLAG_STALEPASSWORD = "thekeyPasswordForceChange";
     public static final String LDAP_FLAG_EMAILVERIFIED = "thekeyAccountVerified";
 
     // LDAP objectClass values

--- a/ldaptive/src/main/java/org/ccci/idm/user/ldaptive/dao/mapper/AbstractUserLdapEntryMapper.java
+++ b/ldaptive/src/main/java/org/ccci/idm/user/ldaptive/dao/mapper/AbstractUserLdapEntryMapper.java
@@ -39,9 +39,9 @@ import static org.ccci.idm.user.dao.ldap.Constants.LDAP_ATTR_USERID;
 import static org.ccci.idm.user.dao.ldap.Constants.LDAP_DEACTIVATED_PREFIX;
 import static org.ccci.idm.user.dao.ldap.Constants.LDAP_FLAG_ALLOWPASSWORDCHANGE;
 import static org.ccci.idm.user.dao.ldap.Constants.LDAP_FLAG_EMAILVERIFIED;
+import static org.ccci.idm.user.dao.ldap.Constants.LDAP_FLAG_FORCEPASSWORDCHANGE;
 import static org.ccci.idm.user.dao.ldap.Constants.LDAP_FLAG_LOCKED;
 import static org.ccci.idm.user.dao.ldap.Constants.LDAP_FLAG_LOGINDISABLED;
-import static org.ccci.idm.user.dao.ldap.Constants.LDAP_FLAG_STALEPASSWORD;
 import static org.ccci.idm.user.dao.ldap.Constants.LDAP_OBJECTCLASSES_USER;
 import static org.ccci.idm.user.dao.ldap.Constants.LDAP_OBJECTCLASS_CRU_PERSON_ATTRIBUTES;
 import static org.ccci.idm.user.dao.ldap.Constants.LDAP_OBJECTCLASS_RELAY_ATTRIBUTES;
@@ -123,7 +123,7 @@ public abstract class AbstractUserLdapEntryMapper<O extends User> implements Lda
         // set several flags for this user
         entry.addAttribute(this.attr(LDAP_FLAG_ALLOWPASSWORDCHANGE, user.isAllowPasswordChange()));
         entry.addAttribute(this.attr(LDAP_FLAG_LOGINDISABLED, user.isLoginDisabled()));
-        entry.addAttribute(this.attr(LDAP_FLAG_STALEPASSWORD, user.isForcePasswordChange()));
+        entry.addAttribute(this.attr(LDAP_FLAG_FORCEPASSWORDCHANGE, user.isForcePasswordChange()));
         entry.addAttribute(this.attr(LDAP_FLAG_EMAILVERIFIED, user.isEmailVerified()));
 
         // set the multi-valued attributes
@@ -233,7 +233,7 @@ public abstract class AbstractUserLdapEntryMapper<O extends User> implements Lda
         user.setAllowPasswordChange(this.getBooleanValue(entry, LDAP_FLAG_ALLOWPASSWORDCHANGE, true));
         user.setLoginDisabled(this.getBooleanValue(entry, LDAP_FLAG_LOGINDISABLED, false));
         user.setLocked(this.getBooleanValue(entry, LDAP_FLAG_LOCKED, false));
-        user.setForcePasswordChange(this.getBooleanValue(entry, LDAP_FLAG_STALEPASSWORD, false));
+        user.setForcePasswordChange(this.getBooleanValue(entry, LDAP_FLAG_FORCEPASSWORDCHANGE, false));
         user.setEmailVerified(this.getBooleanValue(entry, LDAP_FLAG_EMAILVERIFIED, false));
 
         // various self-service keys


### PR DESCRIPTION
when we update a user's password we should probably reset the force password change flag
