### PR TITLE
add support for saving the loginTime

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -37,7 +37,6 @@
       <dependency>
           <groupId>joda-time</groupId>
           <artifactId>joda-time</artifactId>
-          <version>2.3</version>
       </dependency>
 
     <dependency>

--- a/api/src/main/java/org/ccci/idm/user/User.java
+++ b/api/src/main/java/org/ccci/idm/user/User.java
@@ -8,7 +8,7 @@ import com.google.common.base.Objects;
 import com.google.common.base.Predicates;
 import com.google.common.collect.Collections2;
 import com.google.common.collect.Sets;
-import org.joda.time.DateTime;
+import org.joda.time.ReadableInstant;
 import org.springframework.util.StringUtils;
 
 import java.io.Serializable;
@@ -33,7 +33,7 @@ public class User implements Cloneable, Serializable {
     private String firstName;
     private String lastName;
 
-    private DateTime loginTime;
+    private ReadableInstant loginTime;
 
     // account flags
     private boolean emailVerified = false;
@@ -207,12 +207,12 @@ public class User implements Cloneable, Serializable {
         this.lastName = lastName;
     }
 
-    public DateTime getLoginTime()
+    public ReadableInstant getLoginTime()
     {
         return loginTime;
     }
 
-    public void setLoginTime(DateTime loginTime)
+    public void setLoginTime(final ReadableInstant loginTime)
     {
         this.loginTime = loginTime;
     }

--- a/ldaptive/src/main/java/org/ccci/idm/user/ldaptive/dao/io/ReadableInstantValueTranscoder.java
+++ b/ldaptive/src/main/java/org/ccci/idm/user/ldaptive/dao/io/ReadableInstantValueTranscoder.java
@@ -1,0 +1,31 @@
+package org.ccci.idm.user.ldaptive.dao.io;
+
+import org.joda.time.Instant;
+import org.joda.time.ReadableInstant;
+import org.joda.time.format.DateTimeFormat;
+import org.joda.time.format.DateTimeFormatter;
+import org.ldaptive.io.AbstractStringValueTranscoder;
+import org.ldaptive.io.GeneralizedTimeValueTranscoder;
+
+public class ReadableInstantValueTranscoder extends AbstractStringValueTranscoder<ReadableInstant> {
+    private static final GeneralizedTimeValueTranscoder TRANSCODER = new GeneralizedTimeValueTranscoder();
+
+    private static final DateTimeFormatter FORMATTER = DateTimeFormat.forPattern("yyyyMMddHHmmss'Z'").withZoneUTC();
+
+    @Override
+    public Class<ReadableInstant> getType() {
+        return ReadableInstant.class;
+    }
+
+    @Override
+    public ReadableInstant decodeStringValue(final String value) {
+        return new Instant(TRANSCODER.decodeStringValue(value));
+    }
+
+    @Override
+    public String encodeStringValue(final ReadableInstant value) {
+        // we use a custom DateTimeFormatter instead of the GeneralizedTimeValueTranscoder because eDirectory does
+        // not support fractional seconds
+        return FORMATTER.print(value);
+    }
+}

--- a/ldaptive/src/main/java/org/ccci/idm/user/ldaptive/dao/mapper/AbstractUserLdapEntryMapper.java
+++ b/ldaptive/src/main/java/org/ccci/idm/user/ldaptive/dao/mapper/AbstractUserLdapEntryMapper.java
@@ -50,9 +50,8 @@ import com.google.common.base.Joiner;
 import com.google.common.base.Strings;
 import com.google.common.base.Throwables;
 import org.ccci.idm.user.User;
-import org.joda.time.DateTime;
-import org.joda.time.format.DateTimeFormat;
-import org.joda.time.format.DateTimeFormatter;
+import org.ccci.idm.user.ldaptive.dao.io.ReadableInstantValueTranscoder;
+import org.joda.time.ReadableInstant;
 import org.ldaptive.LdapAttribute;
 import org.ldaptive.LdapEntry;
 import org.ldaptive.LdapException;
@@ -76,6 +75,7 @@ public abstract class AbstractUserLdapEntryMapper<O extends User> implements Lda
     private static final Joiner JOINER_STRENGTH = Joiner.on("$").useForNull("");
 
     private static final ValueTranscoder<Boolean> TRANSCODER_BOOLEAN = new BooleanValueTranscoder(true);
+    private static final ValueTranscoder<ReadableInstant> TRANSCODER_INSTANT = new ReadableInstantValueTranscoder();
 
     @NotNull
     protected DnResolver dnResolver;
@@ -139,10 +139,10 @@ public abstract class AbstractUserLdapEntryMapper<O extends User> implements Lda
         if (StringUtils.hasText(password)) {
             entry.addAttribute(this.attr(LDAP_ATTR_PASSWORD, password));
         }
-//        final Date loginTime = user.getLoginTime();
-//        if (loginTime != null) {
-//            entry.addAttribute(this.attr(LDAP_ATTR_LOGINTIME, loginTime));
-//        }
+        final ReadableInstant loginTime = user.getLoginTime();
+        if (loginTime != null) {
+            entry.addAttribute(this.attr(LDAP_ATTR_LOGINTIME, loginTime));
+        }
 
         // set any federated identities
         final String facebookId = user.getFacebookId();
@@ -290,6 +290,12 @@ public abstract class AbstractUserLdapEntryMapper<O extends User> implements Lda
         return attr;
     }
 
+    protected final LdapAttribute attr(final String name, final ReadableInstant... values) {
+        final LdapAttribute attr = new LdapAttribute(name);
+        attr.addValue(TRANSCODER_INSTANT, values);
+        return attr;
+    }
+
     protected LdapAttribute attrObjectClass(final O user) {
         final LdapAttribute attr = new LdapAttribute(LDAP_ATTR_OBJECTCLASS, LDAP_OBJECTCLASSES_USER);
         if(hasCruPersonAttributes(user)) {
@@ -337,17 +343,21 @@ public abstract class AbstractUserLdapEntryMapper<O extends User> implements Lda
         return defaultValue;
     }
 
-    // loginTime format
-    public static final DateTimeFormatter formatter = DateTimeFormat.forPattern("yyyyMMddHHmmssZ").withZoneUTC();
+    protected final ReadableInstant getTimeValue(final LdapEntry entry, final String attribute) {
+        return this.getTimeValue(entry, attribute, null);
+    }
 
-    protected final DateTime getTimeValue(final LdapEntry entry, final String attribute) {
-        try {
-            String dateTimeString = getStringValue(entry, attribute);
-            return formatter.parseDateTime(dateTimeString);
+    protected final ReadableInstant getTimeValue(final LdapEntry entry, final String attribute,
+                                                 final ReadableInstant defaultValue) {
+        final LdapAttribute attr = entry.getAttribute(attribute);
+        if (attr != null) {
+            final ReadableInstant value = attr.getValue(TRANSCODER_INSTANT);
+            if (value != null) {
+                return value;
+            }
         }
-        catch(Exception e) {
-            return null;
-        }
+
+        return defaultValue;
     }
 
     protected final Map<String, Double> getStrengthValues(final LdapEntry entry, final String name) {


### PR DESCRIPTION
Changes:
- centralized the custom encoding/decoding logic into a ValueTranscoder.
- utilize GeneralizedTimeValueTranscoder for decoding since it has more robust parsing support built-in
- widened loginTime class to base Joda Time instant interface
- added a test for saving, reading, and updating the login time
