### PR TITLE
Update UserAlreadyExistsException hierarchy

### DIFF
--- a/api/src/main/java/org/ccci/idm/user/DefaultUserManager.java
+++ b/api/src/main/java/org/ccci/idm/user/DefaultUserManager.java
@@ -3,9 +3,9 @@ package org.ccci.idm.user;
 import com.github.inspektr.audit.annotation.Audit;
 import org.ccci.idm.user.dao.ExceededMaximumAllowedResultsException;
 import org.ccci.idm.user.dao.UserDao;
+import org.ccci.idm.user.exception.EmailAlreadyExistsException;
 import org.ccci.idm.user.exception.RelayGuidAlreadyExistsException;
 import org.ccci.idm.user.exception.TheKeyGuidAlreadyExistsException;
-import org.ccci.idm.user.exception.UserAlreadyExistsException;
 import org.ccci.idm.user.exception.UserException;
 import org.ccci.idm.user.exception.UserNotFoundException;
 import org.ccci.idm.user.util.DefaultRandomPasswordGenerator;
@@ -83,8 +83,8 @@ public class DefaultUserManager implements UserManager {
 
         // throw an error if a user already exists for this email
         if (this.doesEmailExist(user.getEmail())) {
-            LOG.debug("The specified user '{}' already exists.", user.getEmail());
-            throw new UserAlreadyExistsException();
+            LOG.debug("The specified email '{}' already exists.", user.getEmail());
+            throw new EmailAlreadyExistsException();
         }
 
         // throw an error if the raw Relay or The Key guid exists already
@@ -160,7 +160,7 @@ public class DefaultUserManager implements UserManager {
             final String error = "Unable to reactivate user because an account with the email address '" + user
                     .getEmail() + "' currently exists";
             LOG.error(error);
-            throw new UserAlreadyExistsException(error);
+            throw new EmailAlreadyExistsException(error);
         }
 
         // Create a deep clone copy before proceeding

--- a/api/src/main/java/org/ccci/idm/user/UserManager.java
+++ b/api/src/main/java/org/ccci/idm/user/UserManager.java
@@ -1,6 +1,7 @@
 package org.ccci.idm.user;
 
 import org.ccci.idm.user.dao.ExceededMaximumAllowedResultsException;
+import org.ccci.idm.user.exception.EmailAlreadyExistsException;
 import org.ccci.idm.user.exception.UserAlreadyExistsException;
 import org.ccci.idm.user.exception.UserException;
 import org.ccci.idm.user.exception.UserNotFoundException;
@@ -38,7 +39,8 @@ public interface UserManager {
      * Reactivate a previously deactivated user.
      *
      * @param user {@link User} to reactivate
-     * @throws UserAlreadyExistsException thrown if the user being reactivated already exists
+     * @throws EmailAlreadyExistsException thrown if the user being reactivated conflicts with another user that
+     * already exists
      */
     void reactivateUser(User user) throws UserException;
 

--- a/api/src/main/java/org/ccci/idm/user/exception/EmailAlreadyExistsException.java
+++ b/api/src/main/java/org/ccci/idm/user/exception/EmailAlreadyExistsException.java
@@ -1,0 +1,13 @@
+package org.ccci.idm.user.exception;
+
+public class EmailAlreadyExistsException extends UserAlreadyExistsException {
+    private static final long serialVersionUID = -345912295700798200L;
+
+    public EmailAlreadyExistsException() {
+        super();
+    }
+
+    public EmailAlreadyExistsException(final String message) {
+        super(message);
+    }
+}

--- a/api/src/main/java/org/ccci/idm/user/exception/RelayGuidAlreadyExistsException.java
+++ b/api/src/main/java/org/ccci/idm/user/exception/RelayGuidAlreadyExistsException.java
@@ -1,6 +1,6 @@
 package org.ccci.idm.user.exception;
 
-public class RelayGuidAlreadyExistsException extends UserException {
+public class RelayGuidAlreadyExistsException extends UserAlreadyExistsException {
     private static final long serialVersionUID = 6899292295712606400L;
 
     public RelayGuidAlreadyExistsException() {

--- a/api/src/main/java/org/ccci/idm/user/exception/TheKeyGuidAlreadyExistsException.java
+++ b/api/src/main/java/org/ccci/idm/user/exception/TheKeyGuidAlreadyExistsException.java
@@ -1,6 +1,6 @@
 package org.ccci.idm.user.exception;
 
-public class TheKeyGuidAlreadyExistsException extends UserException {
+public class TheKeyGuidAlreadyExistsException extends UserAlreadyExistsException {
     private static final long serialVersionUID = 5470942112218454006L;
 
     public TheKeyGuidAlreadyExistsException() {


### PR DESCRIPTION
This update allows code to catch all UserAlreadyExistsExceptions at once, but still provide individual exceptions for individual issues.
