### PR TITLE
CN should be set through the DN only

### DIFF
--- a/ldaptive/src/main/java/org/ccci/idm/user/ldaptive/dao/mapper/AbstractUserLdapEntryMapper.java
+++ b/ldaptive/src/main/java/org/ccci/idm/user/ldaptive/dao/mapper/AbstractUserLdapEntryMapper.java
@@ -123,8 +123,6 @@ public abstract class AbstractUserLdapEntryMapper<O extends User> implements Lda
         entry.addAttribute(this.attrObjectClass(user));
 
         // set the email for this user
-        entry.addAttribute(this.attr(LDAP_ATTR_CN, user.isDeactivated() ? LDAP_DEACTIVATED_PREFIX + user.getGuid()
-                : user.getEmail()));
         entry.addAttribute(this.attr(LDAP_ATTR_USERID, user.getEmail()));
 
         // set the simple attributes for this user


### PR DESCRIPTION
This attribute is redundant and caused entries to have multiple CN's when creating a new deactivated user.