### PR TITLE
Create migration specific artifact version number.

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.ccci.gto</groupId>
     <artifactId>idm-user-management</artifactId>
-    <version>0.1.0-SNAPSHOT</version>
+    <version>0.1.0-MIGRATION-SNAPSHOT</version>
   </parent>
 
   <artifactId>idm-user-management-api</artifactId>

--- a/inspektr/pom.xml
+++ b/inspektr/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.ccci.gto</groupId>
     <artifactId>idm-user-management</artifactId>
-    <version>0.1.0-SNAPSHOT</version>
+    <version>0.1.0-MIGRATION-SNAPSHOT</version>
   </parent>
 
   <artifactId>idm-user-management-inspektr</artifactId>

--- a/ldaptive/pom.xml
+++ b/ldaptive/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.ccci.gto</groupId>
     <artifactId>idm-user-management</artifactId>
-    <version>0.1.0-SNAPSHOT</version>
+    <version>0.1.0-MIGRATION-SNAPSHOT</version>
   </parent>
 
   <artifactId>idm-user-management-ldaptive</artifactId>

--- a/migration/pom.xml
+++ b/migration/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.ccci.gto</groupId>
     <artifactId>idm-user-management</artifactId>
-    <version>0.1.0-SNAPSHOT</version>
+    <version>0.1.0-MIGRATION-SNAPSHOT</version>
   </parent>
 
   <artifactId>idm-user-management-migration</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
   </parent>
 
   <artifactId>idm-user-management</artifactId>
-  <version>0.1.0-SNAPSHOT</version>
+  <version>0.1.0-MIGRATION-SNAPSHOT</version>
   <packaging>pom</packaging>
 
   <modules>


### PR DESCRIPTION
@frett 

I want to make sure my migration project uses a different version of idm-user-management than my non migration projects.