### PR TITLE
Don't log the full exception stack trace

### DIFF
--- a/ldaptive/src/main/java/org/ccci/idm/user/ldaptive/dao/mapper/AbstractUserLdapEntryMapper.java
+++ b/ldaptive/src/main/java/org/ccci/idm/user/ldaptive/dao/mapper/AbstractUserLdapEntryMapper.java
@@ -373,7 +373,7 @@ public abstract class AbstractUserLdapEntryMapper<O extends User> implements Lda
                 try {
                     groups.add(groupValueTranscoder.decodeStringValue(dn));
                 } catch (final Exception e) {
-                    LOG.info("Caught exception resolving group from group dn {}", dn, e);
+                    LOG.info("Caught exception resolving group from group dn {}", dn);
                 }
             }
         }


### PR DESCRIPTION
Because Relay users are members of role groups not allowed by the `GroupValueTranscoder` which is configured with group base dn (ou=relay,ou=group,dc=ccci,dc=org), exceptions with stack trace are being logged as below, which muddy up the log unnecessarily. So, don't log the full exception stack trace, as this is info level logging and enough info is logged without it. 

AbstractUserLdapEntryMapper.getGroupValues(376) - Caught exception resolving group from group dn cn=readers,ou=system,ou=role,dc=ccci,dc=org
java.lang.IllegalArgumentException: cn=readers,ou=system,ou=role,dc=ccci,dc=org
<full stack trace>

Another option I suppose is to make the group base dn shorter (i.e. dc=ccci,dc=org). However, this seems non intuitive and also the app in question has no interest in groups other than those specified in the group base dn above.

@frett 
