### PR TITLE
Preserve emailVerified flag when we aren't actually changing the email

### DIFF
--- a/api/src/main/java/org/ccci/idm/user/User.java
+++ b/api/src/main/java/org/ccci/idm/user/User.java
@@ -27,6 +27,7 @@ public class User implements Cloneable, Serializable {
     public enum Attr {EMAIL, PASSWORD, NAME, LOGINTIME, FLAGS, SELFSERVICEKEYS, DOMAINSVISITED, FACEBOOK, RELAY_GUID,
        LOCATION, EMPLOYEE_NUMBER, CRU_DESIGNATION, CONTACT, CRU_PREFERRED_NAME, CRU_PROXY_ADDRESSES, HUMAN_RESOURCE }
 
+    @Nullable
     private String email;
     private String password;
 
@@ -140,15 +141,20 @@ public class User implements Cloneable, Serializable {
         this.implMeta.putAll(source.implMeta);
     }
 
+    @Nullable
     public String getEmail() {
         return this.email;
     }
 
-    public void setEmail(final String email) {
-        this.setEmail(email, false);
+    public void setEmail(@Nullable final String email) {
+        // preserve the emailVerified flag if the email isn't actually changing
+        // (case changes are not considered changing emails)
+        final boolean noChange = this.email == null ? email == null : this.email.equalsIgnoreCase(email);
+        //noinspection SimplifiableConditionalExpression
+        this.setEmail(email, noChange ? this.emailVerified : false);
     }
 
-    public void setEmail(final String email, final boolean verified) {
+    public void setEmail(@Nullable final String email, final boolean verified) {
         this.email = email;
         this.emailVerified = verified;
     }

--- a/api/src/test/java/org/ccci/idm/user/UserTest.java
+++ b/api/src/test/java/org/ccci/idm/user/UserTest.java
@@ -11,6 +11,7 @@ import org.apache.commons.collections.CollectionUtils;
 import org.junit.Test;
 
 import java.security.SecureRandom;
+import java.util.Locale;
 import java.util.Random;
 
 public class UserTest {
@@ -150,6 +151,27 @@ public class UserTest {
             assertFalse(user.isEmailVerified());
             user.setEmail(randomEmail(), true);
             assertTrue(user.isEmailVerified());
+        }
+
+        // test preserving emailVerified flag when setting email to same address or changing case of email
+        {
+            user.setEmailVerified(true);
+            assertTrue(user.isEmailVerified());
+            user.setEmail(user.getEmail());
+            assertTrue(user.isEmailVerified());
+            user.setEmail(user.getEmail().toUpperCase(Locale.US));
+            assertTrue(user.isEmailVerified());
+            user.setEmail(user.getEmail().toLowerCase(Locale.US));
+            assertTrue(user.isEmailVerified());
+
+            user.setEmailVerified(false);
+            assertFalse(user.isEmailVerified());
+            user.setEmail(user.getEmail());
+            assertFalse(user.isEmailVerified());
+            user.setEmail(user.getEmail().toUpperCase(Locale.US));
+            assertFalse(user.isEmailVerified());
+            user.setEmail(user.getEmail().toLowerCase(Locale.US));
+            assertFalse(user.isEmailVerified());
         }
     }
 }

--- a/api/src/test/java/org/ccci/idm/user/UserTest.java
+++ b/api/src/test/java/org/ccci/idm/user/UserTest.java
@@ -155,6 +155,8 @@ public class UserTest {
 
         // test preserving emailVerified flag when setting email to same address or changing case of email
         {
+            user.setEmail(randomEmail());
+            assert user.getEmail() != null;
             user.setEmailVerified(true);
             assertTrue(user.isEmailVerified());
             user.setEmail(user.getEmail());

--- a/ldaptive/src/main/java/org/ccci/idm/user/ldaptive/dao/mapper/AbstractUserLdapEntryMapper.java
+++ b/ldaptive/src/main/java/org/ccci/idm/user/ldaptive/dao/mapper/AbstractUserLdapEntryMapper.java
@@ -311,6 +311,7 @@ public abstract class AbstractUserLdapEntryMapper<O extends User> implements Lda
         return id != null ? JOINER_STRENGTH.join(id, strength) : null;
     }
 
+    @Nullable
     protected final String getStringValue(final LdapEntry entry, final String attribute) {
         final LdapAttribute attr = entry.getAttribute(attribute);
         if (attr != null) {
@@ -319,6 +320,7 @@ public abstract class AbstractUserLdapEntryMapper<O extends User> implements Lda
         return null;
     }
 
+    @Nonnull
     protected final Collection<String> getStringValues(final LdapEntry entry, final String attribute) {
         final LdapAttribute attr = entry.getAttribute(attribute);
         if (attr != null) {


### PR DESCRIPTION
addresses a corner case of reseting an email address to itself would make it unverified.