### PR TITLE
create a UserManagerListener interface

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -18,6 +18,11 @@
     </dependency>
     <dependency>
       <groupId>org.springframework</groupId>
+      <artifactId>spring-beans</artifactId>
+      <optional>true</optional><!-- Only used for annotations -->
+    </dependency>
+    <dependency>
+      <groupId>org.springframework</groupId>
       <artifactId>spring-core</artifactId>
     </dependency>
 
@@ -64,11 +69,6 @@
     <dependency>
       <groupId>commons-collections</groupId>
       <artifactId>commons-collections</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.springframework</groupId>
-      <artifactId>spring-beans</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/api/src/main/java/org/ccci/idm/user/DefaultUserManager.java
+++ b/api/src/main/java/org/ccci/idm/user/DefaultUserManager.java
@@ -37,7 +37,7 @@ public class DefaultUserManager implements UserManager {
 
     @NotNull
     @Autowired(required = false)
-    private List<UserManagerListener> listeners = ImmutableList.of();
+    private List<? extends UserManagerListener> listeners = ImmutableList.of();
 
     @NotNull
     protected RandomPasswordGenerator randomPasswordGenerator = new DefaultRandomPasswordGenerator();
@@ -46,7 +46,7 @@ public class DefaultUserManager implements UserManager {
     @NotNull
     protected UserDao userDao;
 
-    public void setListeners(@Nonnull final List<UserManagerListener> listeners) {
+    public void setListeners(@Nonnull final List<? extends UserManagerListener> listeners) {
         this.listeners = listeners;
     }
 

--- a/api/src/main/java/org/ccci/idm/user/DefaultUserManager.java
+++ b/api/src/main/java/org/ccci/idm/user/DefaultUserManager.java
@@ -152,7 +152,7 @@ public class DefaultUserManager implements UserManager {
 
         // trigger any post update listeners
         for (final UserManagerListener listener : listeners) {
-            listener.onPostUpdateUser(user, attrs);
+            listener.onPostUpdateUser(original, user, attrs);
         }
     }
 
@@ -341,7 +341,7 @@ public class DefaultUserManager implements UserManager {
     public interface UserManagerListener {
         void onPostCreateUser(@Nonnull User user);
 
-        void onPostUpdateUser(@Nonnull User user, @Nonnull User.Attr... attrs);
+        void onPostUpdateUser(@Nonnull User original, @Nonnull User user, @Nonnull User.Attr... attrs);
 
         void onPostDeactivateUser(@Nonnull User user);
 
@@ -353,7 +353,7 @@ public class DefaultUserManager implements UserManager {
         public void onPostCreateUser(@Nonnull final User user) {}
 
         @Override
-        public void onPostUpdateUser(@Nonnull final User user, @Nonnull final User.Attr... attrs) {}
+        public void onPostUpdateUser(@Nonnull User original, @Nonnull final User user, @Nonnull final User.Attr... attrs) {}
 
         @Override
         public void onPostDeactivateUser(@Nonnull final User user) {}

--- a/api/src/test/java/org/ccci/idm/user/AbstractDefaultUserManagerIT.java
+++ b/api/src/test/java/org/ccci/idm/user/AbstractDefaultUserManagerIT.java
@@ -134,8 +134,9 @@ public abstract class AbstractDefaultUserManagerIT {
         }
 
         @Override
-        public void onPostUpdateUser(@Nonnull final User user, @Nonnull final User.Attr... attrs) {
-            super.onPostUpdateUser(user, attrs);
+        public void onPostUpdateUser(@Nonnull final User original, @Nonnull final User user,
+                                     @Nonnull final User.Attr... attrs) {
+            super.onPostUpdateUser(original, user, attrs);
 
             assertEquals(this.user.getEmail(), user.getEmail());
             assertEquals(this.user.getFirstName(), user.getFirstName());

--- a/api/src/test/java/org/ccci/idm/user/AbstractDefaultUserManagerIT.java
+++ b/api/src/test/java/org/ccci/idm/user/AbstractDefaultUserManagerIT.java
@@ -1,16 +1,22 @@
 package org.ccci.idm.user;
 
+import static org.ccci.idm.user.TestUtil.guid;
 import static org.ccci.idm.user.TestUtil.newUser;
 import static org.ccci.idm.user.TestUtil.randomEmail;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import static org.junit.Assume.assumeNotNull;
 
+import com.google.common.collect.ImmutableList;
+import org.ccci.idm.user.DefaultUserManager.SimpleUserManagerListener;
+import org.ccci.idm.user.DefaultUserManager.UserManagerListener;
 import org.ccci.idm.user.exception.InvalidEmailUserException;
 import org.junit.Test;
 import org.springframework.beans.factory.annotation.Value;
 
+import javax.annotation.Nonnull;
 import javax.inject.Inject;
 import javax.validation.constraints.NotNull;
 import java.security.SecureRandom;
@@ -63,6 +69,108 @@ public abstract class AbstractDefaultUserManagerIT {
                 // This exception is expected
             }
             assertFalse(this.userManager.doesEmailExist(user.getEmail()));
+        }
+    }
+
+    @Test
+    public void testListeners() throws Exception {
+        assumeConfigured();
+
+        // wrap in a try block to reset listeners once we finish
+        try {
+            final ListenerTestUserManagerListener listener = new ListenerTestUserManagerListener();
+            userManager.setListeners(ImmutableList.of(listener));
+
+            // test user creation
+            final User user = newUser();
+            listener.user = user.clone();
+            assertFalse(listener.postCreateCalled);
+            userManager.createUser(listener.user);
+            assertTrue(listener.postCreateCalled);
+
+            // test user update
+            user.setFirstName("abcdefghijklmnopqrstuvwxyzabcdef");
+            user.setLastName(guid());
+            listener.user = user.clone();
+            assertFalse(listener.postUpdateCalled);
+            assertFalse(listener.nameUpdated);
+            assertFalse(listener.passwordUpdated);
+            userManager.updateUser(user, User.Attr.NAME);
+            assertTrue(listener.postUpdateCalled);
+            assertTrue(listener.nameUpdated);
+            assertFalse(listener.passwordUpdated);
+
+            // test deactivation
+            listener.user = user.clone();
+            assertFalse(listener.postDeactivatedCalled);
+            userManager.deactivateUser(user);
+            assertTrue(listener.postDeactivatedCalled);
+
+            // test reactivation
+            listener.user = user.clone();
+            assertFalse(listener.postReactivatedCalled);
+            userManager.reactivateUser(user);
+            assertTrue(listener.postReactivatedCalled);
+        } finally {
+            userManager.setListeners(ImmutableList.<UserManagerListener>of());
+        }
+    }
+
+    private static class ListenerTestUserManagerListener extends SimpleUserManagerListener {
+        private User user;
+        private boolean postCreateCalled = false;
+        private boolean postUpdateCalled = false;
+        private boolean postDeactivatedCalled = false;
+        private boolean postReactivatedCalled = false;
+        private boolean nameUpdated = false;
+        private boolean passwordUpdated = false;
+
+        @Override
+        public void onPostCreateUser(@Nonnull final User user) {
+            super.onPostCreateUser(user);
+
+            assertEquals(this.user.getEmail(), user.getEmail());
+            postCreateCalled = true;
+        }
+
+        @Override
+        public void onPostUpdateUser(@Nonnull final User user, @Nonnull final User.Attr... attrs) {
+            super.onPostUpdateUser(user, attrs);
+
+            assertEquals(this.user.getEmail(), user.getEmail());
+            assertEquals(this.user.getFirstName(), user.getFirstName());
+            assertEquals(this.user.getLastName(), user.getLastName());
+            postUpdateCalled = true;
+            for (final User.Attr attr : attrs) {
+                switch (attr) {
+                    case NAME:
+                        nameUpdated = true;
+                        break;
+                    case PASSWORD:
+                        passwordUpdated = true;
+                        break;
+                    default:
+                        fail("unexpected attribute update!");
+                }
+            }
+        }
+
+        @Override
+        public void onPostDeactivateUser(@Nonnull final User user) {
+            super.onPostDeactivateUser(user);
+
+            assertEquals(this.user.getEmail(), user.getEmail());
+            assertTrue(user.isDeactivated());
+            postDeactivatedCalled = true;
+        }
+
+        @Override
+        public void onPostReactivateUser(@Nonnull final User user) {
+            super.onPostDeactivateUser(user);
+
+            assertEquals(this.user.getEmail(), user.getEmail());
+            assertFalse(user.isDeactivated());
+            postReactivatedCalled = true;
         }
     }
 

--- a/api/src/test/java/org/ccci/idm/user/AbstractDefaultUserManagerIT.java
+++ b/api/src/test/java/org/ccci/idm/user/AbstractDefaultUserManagerIT.java
@@ -85,7 +85,7 @@ public abstract class AbstractDefaultUserManagerIT {
             final User user = newUser();
             listener.user = user.clone();
             assertFalse(listener.postCreateCalled);
-            userManager.createUser(listener.user);
+            userManager.createUser(user);
             assertTrue(listener.postCreateCalled);
 
             // test user update


### PR DESCRIPTION
This interface can be used to tie external functionality into the UserManager.
Such as: Global Registry sync, Password Policy enforcement, or Password history
tracking. More methods will be added as needed over time.