### PR TITLE
Replace bcrypt with jasypt strong password encryption

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -70,6 +70,12 @@
       </exclusions>
     </dependency>
 
+    <dependency>
+      <groupId>org.jasypt</groupId>
+      <artifactId>jasypt</artifactId>
+      <version>1.9.2</version>
+    </dependency>
+
     <!-- Test Dependencies -->
     <dependency>
       <groupId>commons-collections</groupId>

--- a/api/src/main/java/org/ccci/idm/user/User.java
+++ b/api/src/main/java/org/ccci/idm/user/User.java
@@ -494,7 +494,8 @@ public class User implements Cloneable, Serializable {
     public boolean checkSecurityAnswer(final String securityAnswer) {
         final String normalized = normalize(securityAnswer);
         return !Strings.isNullOrEmpty(this.securityAnswer) && !Strings.isNullOrEmpty(normalized) &&
-                HashUtility.checkHash(normalized, this.securityAnswer);
+                (HashUtility.checkHash(normalized, this.securityAnswer) ||
+                        HashUtility.checkHash(securityAnswer, this.securityAnswer));
     }
 
     /**

--- a/api/src/main/java/org/ccci/idm/user/util/HashUtility.java
+++ b/api/src/main/java/org/ccci/idm/user/util/HashUtility.java
@@ -1,6 +1,6 @@
 package org.ccci.idm.user.util;
 
-import org.springframework.security.crypto.bcrypt.BCrypt;
+import org.jasypt.util.password.StrongPasswordEncryptor;
 
 /**
  * Utility class encapsulating a particular hashing algorithm.
@@ -9,13 +9,13 @@ import org.springframework.security.crypto.bcrypt.BCrypt;
  */
 public class HashUtility {
 
-    private static final Integer BCRYPT_WORK_FACTOR = 12;
+    private static StrongPasswordEncryptor passwordEncryptor = new StrongPasswordEncryptor();
 
     public static String getHash(final String string) {
-        return BCrypt.hashpw(string, BCrypt.gensalt(BCRYPT_WORK_FACTOR));
+        return passwordEncryptor.encryptPassword(string);
     }
 
     public static boolean checkHash(final String string, final String hash) {
-        return BCrypt.checkpw(string, hash);
+        return passwordEncryptor.checkPassword(string, hash);
     }
 }

--- a/ldaptive/src/test/java/org/ccci/idm/user/ldaptive/dao/LdaptiveUserDaoIT.java
+++ b/ldaptive/src/test/java/org/ccci/idm/user/ldaptive/dao/LdaptiveUserDaoIT.java
@@ -19,6 +19,7 @@ import com.google.common.collect.Sets;
 import org.ccci.idm.user.Group;
 import org.ccci.idm.user.User;
 import org.ccci.idm.user.dao.exception.ExceededMaximumAllowedResultsException;
+import org.ccci.idm.user.util.HashUtility;
 import org.joda.time.DateTime;
 import org.joda.time.ReadableInstant;
 import org.junit.Test;
@@ -505,6 +506,11 @@ public class LdaptiveUserDaoIT {
         // check for valid update
         foundUser = this.dao.findByGuid(user.getGuid(), false);
         assertEquals(user.getSecurityQuestion(), foundUser.getSecurityQuestion());
+        assertTrue(foundUser.checkSecurityAnswer(securityAnswer));
+
+        // ensure valid check of (non-normalized) literal string hash
+        securityAnswer = "   A  b   C    d   E  f       G   h   I   j   K   l   M n O p Q r S t U v W x Y z    ";
+        foundUser.setSecurityAnswer(HashUtility.getHash(securityAnswer), false);
         assertTrue(foundUser.checkSecurityAnswer(securityAnswer));
     }
 


### PR DESCRIPTION
@frett In order to support legacy Relay security answer hashes.