### PR TITLE
Remove unused User.Attr parameter from validateUpdateUser() signature

### DIFF
--- a/api/src/main/java/org/ccci/idm/user/DefaultUserManager.java
+++ b/api/src/main/java/org/ccci/idm/user/DefaultUserManager.java
@@ -152,7 +152,7 @@ public class DefaultUserManager implements UserManager {
             "IDM_USER_MANAGER_UPDATE_USER_RESOURCE_RESOLVER")
     public void updateUser(final User user, final User.Attr... attrs) throws DaoException, UserException {
         // validate user object before trying to update it
-        this.validateUpdateUser(user, attrs);
+        this.validateUpdateUser(user);
 
         // trigger any pre update listeners
         final User original = this.getFreshUser(user);
@@ -174,7 +174,7 @@ public class DefaultUserManager implements UserManager {
         }
     }
 
-    protected void validateUpdateUser(final User user, final User.Attr... attrs) throws UserException {
+    protected void validateUpdateUser(final User user) throws UserException {
         // perform base user validation
         this.validateUser(user);
     }


### PR DESCRIPTION
@frett This is a very minor change, but seemed worth making while I was making other modifications. Actually, `validateUpdateUser` could be completely eliminated, but since it follows the pattern of `validateNewUser`, it could remain for consistency sake.