### PR TITLE
upgrade to inspektr 1.2.GA for CAS 4.1

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -12,8 +12,9 @@
 
   <dependencies>
     <dependency>
-      <groupId>com.github.inspektr</groupId>
+      <groupId>org.jasig.inspektr</groupId>
       <artifactId>inspektr-audit</artifactId>
+      <version>${inspektr.version}</version>
       <optional>true</optional><!-- Only used for annotations -->
     </dependency>
     <dependency>

--- a/api/src/main/java/org/ccci/idm/user/DefaultUserManager.java
+++ b/api/src/main/java/org/ccci/idm/user/DefaultUserManager.java
@@ -1,6 +1,5 @@
 package org.ccci.idm.user;
 
-import com.github.inspektr.audit.annotation.Audit;
 import com.google.common.base.CharMatcher;
 import com.google.common.collect.FluentIterable;
 import com.google.common.collect.ImmutableList;
@@ -17,6 +16,7 @@ import org.ccci.idm.user.exception.UserNotFoundException;
 import org.ccci.idm.user.util.DefaultRandomPasswordGenerator;
 import org.ccci.idm.user.util.PasswordHistoryManager;
 import org.ccci.idm.user.util.RandomPasswordGenerator;
+import org.jasig.inspektr.audit.annotation.Audit;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;

--- a/inspektr/pom.xml
+++ b/inspektr/pom.xml
@@ -17,8 +17,9 @@
     </dependency>
 
     <dependency>
-      <groupId>com.github.inspektr</groupId>
+      <groupId>org.jasig.inspektr</groupId>
       <artifactId>inspektr-audit</artifactId>
+      <version>${inspektr.version}</version>
     </dependency>
   </dependencies>
 </project>

--- a/inspektr/src/main/java/org/ccci/idm/user/inspektr/spi/UserAuditResourceResolver.java
+++ b/inspektr/src/main/java/org/ccci/idm/user/inspektr/spi/UserAuditResourceResolver.java
@@ -1,9 +1,9 @@
 package org.ccci.idm.user.inspektr.spi;
 
-import com.github.inspektr.audit.spi.support.AbstractAuditResourceResolver;
 import com.google.common.base.MoreObjects;
 import com.google.common.base.MoreObjects.ToStringHelper;
 import org.ccci.idm.user.User;
+import org.jasig.inspektr.audit.spi.support.AbstractAuditResourceResolver;
 
 import javax.annotation.Nonnull;
 

--- a/pom.xml
+++ b/pom.xml
@@ -27,6 +27,7 @@
   <properties>
     <maven.compiler.source>1.6</maven.compiler.source>
     <maven.compiler.target>1.6</maven.compiler.target>
+    <inspektr.version>1.2.GA</inspektr.version>
   </properties>
 
   <dependencyManagement>


### PR DESCRIPTION
The package for inspektr was changed from com.github.inspektr to org.jasig.inspektr