### PR TITLE
Deprecate User.isEmailVerified

### DIFF
--- a/api/src/main/java/org/ccci/idm/user/User.java
+++ b/api/src/main/java/org/ccci/idm/user/User.java
@@ -313,10 +313,12 @@ public class User implements Cloneable, Serializable {
         this.pwdChangedTime = time;
     }
 
+    @Deprecated
     public boolean isEmailVerified() {
         return this.emailVerified;
     }
 
+    @Deprecated
     public void setEmailVerified(final boolean verified) {
         this.emailVerified = verified;
     }

--- a/okta/src/main/java/org/ccci/idm/user/okta/dao/OktaUserDao.kt
+++ b/okta/src/main/java/org/ccci/idm/user/okta/dao/OktaUserDao.kt
@@ -2,7 +2,6 @@ package org.ccci.idm.user.okta.dao
 
 import com.okta.sdk.client.Client
 import com.okta.sdk.resource.ResourceException
-import com.okta.sdk.resource.user.EmailStatus
 import com.okta.sdk.resource.user.UserBuilder
 import com.okta.sdk.resource.user.UserStatus
 import org.ccci.idm.user.Group
@@ -354,8 +353,7 @@ class OktaUserDao(private val okta: Client, private val listeners: List<Listener
                 legacyDeactivated -> profile.getString(PROFILE_ORIGINAL_EMAIL) ?: profile.email
                 else -> profile.email
             }
-            isEmailVerified =
-                credentials.emails.firstOrNull { email.equals(it.value, true) }?.status == EmailStatus.VERIFIED
+            isEmailVerified = true
 
             firstName = profile.firstName
             preferredName = profile.getString(PROFILE_NICK_NAME)


### PR DESCRIPTION
Determining if an email is verified from the Okta Credentials object is error-prone. On our oktapreview config the credentials object no longer contains the emails for a user, which means we can't use the verified status it contains. Because isEmailVerified was a concept used by The Key, and The Key is almost phased out, I'm opting to deprecate isEmailVerified and default it to true for any place it's still used within The Key

HS ticket [#1332907](https://secure.helpscout.net/conversation/2889756038/1332907)